### PR TITLE
Add terraform structure for AWS EC2 with GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+image: hashicorp/terraform:light
+
+stages:
+  - validate
+  - plan
+  - apply
+
+before_script:
+  - terraform version
+  - terraform init -backend=false terraform/environments/dev
+
+validate:
+  stage: validate
+  script:
+    - terraform -chdir=terraform/environments/dev validate
+  rules:
+    - when: always
+
+plan:
+  stage: plan
+  script:
+    - terraform -chdir=terraform/environments/dev plan -out=plan.tfplan
+  artifacts:
+    paths:
+      - terraform/environments/dev/plan.tfplan
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+
+apply:
+  stage: apply
+  script:
+    - terraform -chdir=terraform/environments/dev apply -auto-approve plan.tfplan
+  when: manual
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# ejemplo
+# Example Terraform AWS EC2 Deployment
+
+This repository contains a simple Terraform configuration for deploying an EC2 instance on AWS. It is structured to work with GitLab CI/CD.
+
+## Directory Structure
+
+```
+terraform/
+  modules/
+    ec2/               # Reusable module to provision an EC2 instance
+      main.tf
+      variables.tf
+      outputs.tf
+  environments/
+    dev/               # Example environment using the module
+      provider.tf
+      main.tf
+      variables.tf
+      terraform.tfvars
+      outputs.tf
+.gitlab-ci.yml         # GitLab pipeline definition
+```
+
+## Usage
+
+1. Update the values in `terraform/environments/dev/terraform.tfvars` with the desired AMI and region.
+2. Run `terraform init` and `terraform plan` inside `terraform/environments/dev` to review changes.
+3. Commit and push to trigger the GitLab pipeline.

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,6 @@
+module "ec2" {
+  source        = "../../modules/ec2"
+  ami           = var.ami
+  instance_type = var.instance_type
+  name          = var.name
+}

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_id" {
+  description = "ID of the instance"
+  value       = module.ec2.instance_id
+}

--- a/terraform/environments/dev/provider.tf
+++ b/terraform/environments/dev/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,0 +1,4 @@
+region        = "us-east-1"
+ami           = "ami-12345678"
+instance_type = "t2.micro"
+name          = "example-instance"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "ami" {
+  description = "AMI ID"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "name" {
+  description = "Name tag"
+  type        = string
+  default     = "example-instance"
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "this" {
+  ami           = var.ami
+  instance_type = var.instance_type
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.this.id
+}

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,15 @@
+variable "ami" {
+  description = "AMI ID for the instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "name" {
+  description = "Name tag for the instance"
+  type        = string
+  default     = "example-instance"
+}


### PR DESCRIPTION
## Summary
- add reusable EC2 module and dev environment
- add GitLab CI pipeline for Terraform
- document repository structure and usage in README

## Testing
- `terraform fmt -check -recursive terraform`
- `terraform -chdir=terraform/environments/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform/environments/dev validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6876f27ee7d0832ba9c5d18473171b96